### PR TITLE
feat: Define and generate database schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,125 @@
+-- Categories Table
+CREATE TABLE categories (
+    category_id INT AUTO_INCREMENT PRIMARY KEY,
+    category_name VARCHAR(255) NOT NULL UNIQUE,
+    category_slug VARCHAR(255) NOT NULL UNIQUE,
+    category_description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_category_slug ON categories(category_slug);
+
+-- Products Table
+CREATE TABLE products (
+    product_id INT AUTO_INCREMENT PRIMARY KEY,
+    product_name VARCHAR(255) NOT NULL,
+    product_sku VARCHAR(100) NOT NULL UNIQUE,
+    product_description TEXT,
+    price DECIMAL(10, 2) NOT NULL,
+    stock_quantity INT NOT NULL DEFAULT 0,
+    category_id INT,
+    image_url VARCHAR(2083), -- Standard max URL length
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_product_category
+        FOREIGN KEY (category_id) REFERENCES categories(category_id)
+        ON DELETE SET NULL -- If a category is deleted, products are not deleted but category_id is set to NULL
+        ON UPDATE CASCADE -- If category_id in categories table changes, update it here too
+);
+
+CREATE INDEX idx_product_sku ON products(product_sku);
+CREATE INDEX idx_product_category ON products(category_id);
+CREATE INDEX idx_product_name ON products(product_name);
+
+-- Customers Table
+CREATE TABLE customers (
+    customer_id INT AUTO_INCREMENT PRIMARY KEY,
+    first_name VARCHAR(100) NOT NULL,
+    last_name VARCHAR(100) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL, -- Store hashed passwords
+    phone_number VARCHAR(20),
+    address_line1 VARCHAR(255),
+    address_line2 VARCHAR(255),
+    city VARCHAR(100),
+    state_province VARCHAR(100),
+    postal_code VARCHAR(20),
+    country VARCHAR(100),
+    registration_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_login TIMESTAMP
+);
+
+CREATE INDEX idx_customer_email ON customers(email);
+CREATE INDEX idx_customer_name ON customers(last_name, first_name);
+
+-- Orders Table
+CREATE TABLE orders (
+    order_id INT AUTO_INCREMENT PRIMARY KEY,
+    customer_id INT,
+    order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    order_status ENUM('pending', 'processing', 'shipped', 'delivered', 'cancelled', 'refunded') NOT NULL DEFAULT 'pending',
+    total_amount DECIMAL(10, 2) NOT NULL,
+    shipping_address_line1 VARCHAR(255),
+    shipping_address_line2 VARCHAR(255),
+    shipping_city VARCHAR(100),
+    shipping_state_province VARCHAR(100),
+    shipping_postal_code VARCHAR(20),
+    shipping_country VARCHAR(100),
+    billing_address_line1 VARCHAR(255),
+    billing_address_line2 VARCHAR(255),
+    billing_city VARCHAR(100),
+    billing_state_province VARCHAR(100),
+    billing_postal_code VARCHAR(20),
+    billing_country VARCHAR(100),
+    payment_method VARCHAR(50),
+    payment_status ENUM('pending', 'paid', 'failed', 'refunded') NOT NULL DEFAULT 'pending',
+    transaction_id VARCHAR(255),
+    notes TEXT,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_order_customer
+        FOREIGN KEY (customer_id) REFERENCES customers(customer_id)
+        ON DELETE SET NULL -- Keep order history even if customer account is deleted (or RESTRICT for stricter control)
+        ON UPDATE CASCADE
+);
+
+CREATE INDEX idx_order_customer ON orders(customer_id);
+CREATE INDEX idx_order_status ON orders(order_status);
+CREATE INDEX idx_payment_status ON orders(payment_status);
+
+-- Order Items Table
+CREATE TABLE order_items (
+    order_item_id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT NOT NULL,
+    product_id INT,
+    quantity INT NOT NULL,
+    unit_price DECIMAL(10, 2) NOT NULL, -- Price at the time of order
+    total_price DECIMAL(10, 2) NOT NULL,
+    CONSTRAINT fk_orderitem_order
+        FOREIGN KEY (order_id) REFERENCES orders(order_id)
+        ON DELETE CASCADE -- If an order is deleted, its items are deleted
+        ON UPDATE CASCADE,
+    CONSTRAINT fk_orderitem_product
+        FOREIGN KEY (product_id) REFERENCES products(product_id)
+        ON DELETE RESTRICT -- Do not allow product deletion if it's part of an order
+        ON UPDATE CASCADE
+);
+
+CREATE INDEX idx_orderitem_order ON order_items(order_id);
+CREATE INDEX idx_orderitem_product ON order_items(product_id);
+
+-- Admins Table
+CREATE TABLE admins (
+    admin_id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    full_name VARCHAR(255),
+    role ENUM('superadmin', 'editor', 'viewer') NOT NULL DEFAULT 'editor',
+    last_login TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_admin_username ON admins(username);
+CREATE INDEX idx_admin_email ON admins(email);


### PR DESCRIPTION
Defines the database structure for a bag business management website, including tables for categories, products, customers, orders, order_items, and admins.

The SQL `CREATE TABLE` statements for these tables have been generated and saved to `schema.sql`. This includes primary keys, foreign keys, constraints, default values, and basic indexes to support your application's data storage and retrieval needs.