### PR TITLE
feat: Implement backend category management module

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,0 +1,95 @@
+<?php
+// admin/categories.php
+session_start(); // Start session to manage messages
+
+require_once '../php/db_connect.php';
+require_once '../php/includes/category_functions.php';
+
+$page_title = "Manage Categories";
+
+// Fetch all categories
+$categories = get_all_categories($mysqli);
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($page_title); ?> - Admin</title>
+    <link rel="stylesheet" href="../css/style.css"> // Assuming a general style.css exists
+    <style>
+        /* Basic admin styles */
+        body { font-family: sans-serif; background-color: #f4f4f4; color: #333; margin: 0; padding: 0; }
+        .admin-container { width: 90%; max-width: 1200px; margin: 20px auto; padding: 20px; background: #fff; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1 { color: #333; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+        th, td { border: 1px solid #ddd; padding: 10px; text-align: left; }
+        th { background-color: #f2f2f2; font-weight: bold; }
+        tr:nth-child(even) { background-color: #f9f9f9; }
+        .action-links a, .button {
+            display: inline-block;
+            padding: 8px 12px;
+            margin-right: 5px;
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+        }
+        .button, .action-links a[href*="category_form.php"] { background-color: #5cb85c; color: white; }
+        .action-links a[href*="category_form.php"]:hover { background-color: #4cae4c; }
+
+        .action-links a[href*="category_delete.php"] { background-color: #d9534f; color: white; }
+        .action-links a[href*="category_delete.php"]:hover { background-color: #c9302c; }
+
+        .message { padding: 12px 15px; margin-bottom: 20px; border-radius: 4px; font-size: 0.95em; }
+        .success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
+        .error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+    </style>
+</head>
+<body>
+    <div class="admin-container">
+        <h1><?php echo htmlspecialchars($page_title); ?></h1>
+
+        <?php if (isset($_SESSION['message'])): ?>
+            <div class="message <?php echo isset($_SESSION['message_type']) ? htmlspecialchars($_SESSION['message_type']) : 'success'; ?>">
+                <?php echo htmlspecialchars($_SESSION['message']); ?>
+            </div>
+            <?php unset($_SESSION['message']); unset($_SESSION['message_type']); ?>
+        <?php endif; ?>
+
+        <p><a href="category_form.php" class="button">Add New Category</a></p>
+
+        <?php if (!empty($categories)): ?>
+            <table>
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Name</th>
+                        <th>Slug</th>
+                        <th>Description</th>
+                        <th>Parent ID</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($categories as $category): ?>
+                        <tr>
+                            <td><?php echo htmlspecialchars($category['id']); ?></td>
+                            <td><?php echo htmlspecialchars($category['name']); ?></td>
+                            <td><?php echo htmlspecialchars($category['slug']); ?></td>
+                            <td><?php echo htmlspecialchars($category['description'] ?? ''); ?></td>
+                            <td><?php echo htmlspecialchars($category['parent_id'] ?? 'None'); ?></td>
+                            <td class="action-links">
+                                <a href="category_form.php?edit_id=<?php echo $category['id']; ?>">Edit</a>
+                                <a href="category_delete.php?id=<?php echo $category['id']; ?>" onclick="return confirm('Are you sure you want to delete this category? This might also affect products referencing this category if ON DELETE SET NULL is used, or prevent deletion if ON DELETE RESTRICT is used and products reference it.');">Delete</a>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p>No categories found. <a href="category_form.php">Add one now!</a></p>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/admin/category_delete.php
+++ b/admin/category_delete.php
@@ -1,0 +1,37 @@
+<?php
+// admin/category_delete.php
+session_start();
+
+require_once '../php/db_connect.php'; // Provides $mysqli
+require_once '../php/includes/category_functions.php';
+
+// Check for admin login status here if implementing authentication
+
+if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
+    $_SESSION['message'] = "Invalid category ID for deletion.";
+    $_SESSION['message_type'] = "error";
+    header("Location: categories.php");
+    exit;
+}
+
+$category_id = (int)$_GET['id'];
+
+// Optional: Add a CSRF token check here for better security
+
+// Attempt to delete the category
+// The delete_category function already checks if the category has children and prevents deletion if so.
+// It also depends on how products.category_id FOREIGN KEY is set up (ON DELETE SET NULL or ON DELETE RESTRICT)
+if (delete_category($mysqli, $category_id)) {
+    $_SESSION['message'] = "Category (ID: $category_id) deleted successfully.";
+    $_SESSION['message_type'] = "success";
+} else {
+    // The delete_category function logs specific SQL errors.
+    // A general message is usually sufficient here, or you could try to get more specific error info if needed.
+    // The function `delete_category` itself returns false if children exist, so this message covers that.
+    $_SESSION['message'] = "Failed to delete category (ID: $category_id). It might have child categories, be referenced by products (if ON DELETE RESTRICT is used for products.category_id), or another database error occurred. Please check system logs.";
+    $_SESSION['message_type'] = "error";
+}
+
+header("Location: categories.php");
+exit;
+?>

--- a/admin/category_form.php
+++ b/admin/category_form.php
@@ -1,0 +1,192 @@
+<?php
+// admin/category_form.php
+session_start();
+
+require_once '../php/db_connect.php'; // Provides $mysqli
+require_once '../php/includes/category_functions.php';
+
+$page_title = "Add New Category";
+$form_action = "category_form.php"; // Default action is add
+
+$category_id = null; // ID of the category being edited, null for new category
+$name = '';
+$slug = '';
+$description = '';
+$parent_id_current = null; // Current parent_id of the category being edited or selected
+
+// Check if this is an edit request
+if (isset($_GET['edit_id']) && is_numeric($_GET['edit_id'])) {
+    $category_id = (int)$_GET['edit_id'];
+    $existing_category = get_category_by_id($mysqli, $category_id);
+
+    if ($existing_category) {
+        $page_title = "Edit Category: " . htmlspecialchars($existing_category['name']);
+        $form_action = "category_form.php?edit_id=" . $category_id; // Keep edit_id in action
+
+        $name = $existing_category['name'];
+        $slug = $existing_category['slug'];
+        $description = $existing_category['description'] ?? '';
+        $parent_id_current = $existing_category['parent_id'];
+    } else {
+        $_SESSION['message'] = "Category not found for editing (ID: $category_id).";
+        $_SESSION['message_type'] = "error";
+        header("Location: categories.php");
+        exit;
+    }
+}
+
+// Handle form submission
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Retrieve and sanitize inputs
+    $name = trim($_POST['name'] ?? '');
+    $slug = trim($_POST['slug'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $parent_id_input = trim($_POST['parent_id'] ?? '');
+
+    // If parent_id is empty string or "0", treat as NULL. Otherwise, cast to int.
+    $parent_id_new = ($parent_id_input === '' || $parent_id_input === '0') ? null : (int)$parent_id_input;
+
+    // Basic validation
+    if (empty($name) || empty($slug)) {
+        // Store message to be displayed on the form page itself
+        $_SESSION['form_submission_error'] = "Category Name and Slug are required.";
+        // Values for $name, $slug, $description, $parent_id_current are already set to be redisplayed
+    } else {
+        $success = false;
+        $operation_type = '';
+
+        if ($category_id !== null) { // Update existing category
+            $operation_type = 'update';
+            // Ensure a category is not set as its own parent during an update
+            if ($parent_id_new !== null && $parent_id_new === $category_id) {
+                 $_SESSION['form_submission_error'] = "A category cannot be its own parent.";
+            } else {
+                $success = update_category($mysqli, $category_id, $name, $description, $slug, $parent_id_new);
+            }
+        } else { // Create new category
+            $operation_type = 'create';
+            $new_category_id = create_category($mysqli, $name, $description, $slug, $parent_id_new);
+            $success = ($new_category_id !== false);
+            if ($success) $category_id = $new_category_id; // For potential further use
+        }
+
+        if (isset($_SESSION['form_submission_error'])) {
+             // Error already set (e.g. self-parenting), stay on page
+             // No redirect here
+        } elseif ($success) {
+            $_SESSION['message'] = "Category " . ($operation_type === 'update' ? 'updated' : 'created') . " successfully.";
+            $_SESSION['message_type'] = "success";
+            header("Location: categories.php");
+            exit;
+        } else {
+            $_SESSION['form_submission_error'] = "Failed to " . ($operation_type ?: 'process') . " category. Possible duplicate name/slug or database error. Check logs.";
+            // Stay on page, values will be redisplayed.
+        }
+    }
+    // If validation failed or DB operation failed, we fall through to display the form again with current values and error message.
+    // Update $parent_id_current to what was submitted if there was an error, so dropdown reflects selection.
+    $parent_id_current = $parent_id_new;
+}
+
+// Fetch all categories for the parent dropdown
+// Exclude the current category being edited from the list of potential parents
+$all_categories_for_dropdown = get_all_categories($mysqli);
+$parent_options = [];
+foreach ($all_categories_for_dropdown as $cat) {
+    if ($category_id !== null && $cat['id'] == $category_id) {
+        continue; // Prevent a category from being its own parent
+    }
+    $parent_options[] = $cat;
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($page_title); ?> - Admin</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <style>
+        /* Basic admin styles - reusing some from categories.php for consistency */
+        body { font-family: sans-serif; background-color: #f4f4f4; color: #333; margin: 0; padding: 0; }
+        .admin-container { width: 90%; max-width: 800px; margin: 20px auto; padding: 20px; background: #fff; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1 { color: #333; margin-bottom: 20px; }
+        .form-group { margin-bottom: 15px; }
+        .form-group label { display: block; margin-bottom: 5px; font-weight: bold; }
+        .form-group input[type="text"],
+        .form-group textarea,
+        .form-group select {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            box-sizing: border-box;
+            font-size: 0.95em;
+        }
+        .form-group textarea { min-height: 100px; resize: vertical; }
+        .form-group small { display: block; margin-top: 5px; color: #777; font-size: 0.85em;}
+        .btn-submit { background-color: #5cb85c; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
+        .btn-submit:hover { background-color: #4cae4c; }
+        .cancel-link { margin-left: 10px; color: #337ab7; text-decoration: none; }
+        .cancel-link:hover { text-decoration: underline; }
+
+        .message { padding: 12px 15px; margin-bottom: 20px; border-radius: 4px; font-size: 0.95em; }
+        .success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
+        .error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+    </style>
+</head>
+<body>
+    <div class="admin-container">
+        <h1><?php echo htmlspecialchars($page_title); ?></h1>
+
+        <?php
+        // Display error message from form submission attempt, if any
+        if (isset($_SESSION['form_submission_error'])):
+        ?>
+            <div class="message error">
+                <?php echo htmlspecialchars($_SESSION['form_submission_error']); ?>
+            </div>
+            <?php unset($_SESSION['form_submission_error']); // Clear message after displaying ?>
+        <?php
+        // Or display general message if redirected from another page (e.g., category not found for edit)
+        elseif (isset($_SESSION['message'])):
+        ?>
+             <div class="message <?php echo isset($_SESSION['message_type']) ? htmlspecialchars($_SESSION['message_type']) : 'error'; ?>">
+                <?php echo htmlspecialchars($_SESSION['message']); ?>
+            </div>
+            <?php unset($_SESSION['message']); unset($_SESSION['message_type']); // Clear message after displaying ?>
+        <?php endif; ?>
+
+        <form action="<?php echo htmlspecialchars($form_action); ?>" method="POST">
+            <div class="form-group">
+                <label for="name">Category Name:</label>
+                <input type="text" id="name" name="name" value="<?php echo htmlspecialchars($name); ?>" required>
+            </div>
+            <div class="form-group">
+                <label for="slug">Slug:</label>
+                <input type="text" id="slug" name="slug" value="<?php echo htmlspecialchars($slug); ?>" required>
+                <small>URL-friendly version of the name (e.g., "leather-handbags"). Should be unique.</small>
+            </div>
+            <div class="form-group">
+                <label for="description">Description:</label>
+                <textarea id="description" name="description"><?php echo htmlspecialchars($description); ?></textarea>
+            </div>
+            <div class="form-group">
+                <label for="parent_id">Parent Category:</label>
+                <select id="parent_id" name="parent_id">
+                    <option value="0">None (Top-level Category)</option>
+                    <?php foreach ($parent_options as $option_cat): ?>
+                        <option value="<?php echo $option_cat['id']; ?>" <?php echo ($parent_id_current == $option_cat['id']) ? 'selected' : ''; ?>>
+                            <?php echo htmlspecialchars($option_cat['name']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+                <small>Assigning a parent makes this a sub-category.</small>
+            </div>
+            <button type="submit" class="btn-submit"><?php echo ($category_id !== null) ? 'Update Category' : 'Add Category'; ?></button>
+            <a href="categories.php" class="cancel-link">Cancel</a>
+        </form>
+    </div>
+</body>
+</html>

--- a/php/config.php
+++ b/php/config.php
@@ -1,0 +1,22 @@
+<?php
+
+// Database Configuration
+define('DB_HOST', 'localhost');          // Database host (usually 'localhost' for XAMPP)
+define('DB_USERNAME', 'root');           // Database username (usually 'root' for XAMPP)
+define('DB_PASSWORD', '');               // Database password (empty by default for XAMPP, change if you have set one)
+define('DB_NAME', 'bag_shop_db');        // The name of your database
+
+/*
+Important Security Note:
+In a production environment, this file should be:
+1. Placed outside of the web server's document root if possible.
+2. Have very restrictive file permissions.
+3. Consider using environment variables to store sensitive credentials instead of hardcoding them.
+For XAMPP development, placing it here is generally acceptable for ease of use.
+*/
+
+// Optional: Site URL and Path Configuration (can be useful later)
+// define('SITE_URL', 'http://localhost/your_project_folder_name/'); // Adjust to your project's URL
+// define('BASE_PATH', __DIR__ . '/../'); // Path to the project root
+
+?>

--- a/php/db_connect.php
+++ b/php/db_connect.php
@@ -1,0 +1,32 @@
+<?php
+
+// Include the database configuration file
+require_once 'config.php';
+
+// Attempt to connect to MySQL database
+$mysqli = new mysqli(DB_HOST, DB_USERNAME, DB_PASSWORD, DB_NAME);
+
+// Check connection
+if ($mysqli->connect_error) {
+    // Connection failed. Output error and terminate script.
+    // In a production environment, you might want to log this error instead of displaying it directly.
+    error_log("Database Connection Failed: " . $mysqli->connect_error);
+    die("Sorry, we're experiencing some technical difficulties. Please try again later.");
+    // For development, you might want more detailed errors:
+    // die("Connection Failed: " . $mysqli->connect_error . " (Error Code: " . $mysqli->connect_errno . ")");
+}
+
+// Set character set to utf8mb4 (recommended for full Unicode support)
+if (!$mysqli->set_charset("utf8mb4")) {
+    // In a production environment, log this error.
+    error_log("Error loading character set utf8mb4: " . $mysqli->error);
+    // For development:
+    // printf("Error loading character set utf8mb4: %s
+", $mysqli->error);
+}
+
+// The $mysqli object is now ready for use by other scripts that include this file.
+// Example: require_once 'php/db_connect.php';
+// Then use $mysqli to perform queries.
+
+?>

--- a/php/includes/category_functions.php
+++ b/php/includes/category_functions.php
@@ -1,0 +1,242 @@
+<?php
+
+// Functions for managing categories
+
+/**
+ * Creates a new category.
+ *
+ * @param mysqli $mysqli The database connection object.
+ * @param string $name The name of the category.
+ * @param string|null $description The description of the category (optional).
+ * @param string $slug The URL-friendly slug for the category.
+ * @param int|null $parent_id The ID of the parent category (optional).
+ * @return int|false The ID of the newly created category on success, or false on failure.
+ */
+function create_category(mysqli $mysqli, string $name, ?string $description, string $slug, ?int $parent_id = null) {
+    // The column names in the SQL query were 'name', 'description', 'slug', 'parent_id', 'date_created', 'last_updated'
+    // The schema.sql defined category_id, category_name, category_slug, category_description, created_at, updated_at
+    // Assuming parent_id is a nullable foreign key to categories.category_id if subcategories are allowed.
+    // Let's adjust SQL to match schema.sql and add parent_id if it's part of the design.
+    // For now, assuming schema.sql is the source of truth and it does NOT have parent_id.
+    // If parent_id is needed, schema.sql should be updated first.
+    // Let's use the columns from schema.sql: category_name, category_slug, category_description
+
+    // Corrected SQL based on schema.sql (category_id, category_name, category_slug, category_description, created_at, updated_at)
+    // The original function signature included parent_id, but schema.sql does not.
+    // I will proceed with the function signature provided in the prompt which includes parent_id,
+    // and assume the user will update their schema.sql or understands this discrepancy.
+    // If parent_id column doesn't exist, this INSERT will fail.
+    // For the query, I will use the column names from the prompt's function description: name, description, slug, parent_id
+    // and assume they map to category_name, category_description, category_slug, parent_category_id (hypothetical) in the DB.
+    // Given the schema.sql: category_name, category_slug, category_description.
+    // The function signature has: name, description, slug, parent_id.
+    // I will map them: name -> category_name, description -> category_description, slug -> category_slug.
+    // parent_id will be assumed to be a column named 'parent_id' for this function to work as written.
+    // If 'parent_id' does not exist in 'categories' table, this will cause SQL error.
+
+    $sql = "INSERT INTO categories (category_name, category_description, category_slug, parent_id) VALUES (?, ?, ?, ?)";
+    // created_at and updated_at have defaults in schema.sql
+
+    $stmt = $mysqli->prepare($sql);
+    if (!$stmt) {
+        error_log("Error preparing statement for create_category: " . $mysqli->error);
+        return false;
+    }
+    // Parameters: category_name (string), category_description (string), category_slug (string), parent_id (int or null)
+    $stmt->bind_param("sssi", $name, $description, $slug, $parent_id);
+
+    if ($stmt->execute()) {
+        return $mysqli->insert_id;
+    } else {
+        error_log("Error executing statement for create_category: " . $stmt->error);
+        return false;
+    }
+}
+
+/**
+ * Retrieves a single category by its ID.
+ *
+ * @param mysqli $mysqli The database connection object.
+ * @param int $id The ID of the category.
+ * @return array|null The category data as an associative array, or null if not found or on error.
+ */
+function get_category_by_id(mysqli $mysqli, int $id): ?array {
+    // Using column names from schema.sql: category_id, category_name, category_description, category_slug, created_at, updated_at
+    // The function signature in prompt used 'id', 'name', 'description', 'slug', 'parent_id', 'date_created', 'last_updated'.
+    // Assuming 'id' maps to 'category_id', 'name' to 'category_name' etc.
+    // And assuming 'parent_id' column exists if it's in the SELECT.
+    $sql = "SELECT category_id, category_name, category_description, category_slug, parent_id, created_at, updated_at FROM categories WHERE category_id = ?";
+    $stmt = $mysqli->prepare($sql);
+    if (!$stmt) {
+        error_log("Error preparing statement for get_category_by_id: " . $mysqli->error);
+        return null;
+    }
+    $stmt->bind_param("i", $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result && $result->num_rows > 0) {
+        // Map DB columns to expected keys if they differ, or use DB keys directly.
+        // The prompt implies keys like 'id', 'name'. Let's return them as such for consistency with function doc.
+        $category = $result->fetch_assoc();
+        return [
+            'id' => $category['category_id'],
+            'name' => $category['category_name'],
+            'description' => $category['category_description'],
+            'slug' => $category['category_slug'],
+            'parent_id' => $category['parent_id'] ?? null, // Assuming parent_id might not exist or be null
+            'date_created' => $category['created_at'],
+            'last_updated' => $category['updated_at']
+        ];
+    }
+    return null;
+}
+
+/**
+ * Retrieves a single category by its slug.
+ *
+ * @param mysqli $mysqli The database connection object.
+ * @param string $slug The slug of the category.
+ * @return array|null The category data as an associative array, or null if not found or on error.
+ */
+function get_category_by_slug(mysqli $mysqli, string $slug): ?array {
+    $sql = "SELECT category_id, category_name, category_description, category_slug, parent_id, created_at, updated_at FROM categories WHERE category_slug = ?";
+    $stmt = $mysqli->prepare($sql);
+    if (!$stmt) {
+        error_log("Error preparing statement for get_category_by_slug: " . $mysqli->error);
+        return null;
+    }
+    $stmt->bind_param("s", $slug);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result && $result->num_rows > 0) {
+        $category = $result->fetch_assoc();
+        return [
+            'id' => $category['category_id'],
+            'name' => $category['category_name'],
+            'description' => $category['category_description'],
+            'slug' => $category['category_slug'],
+            'parent_id' => $category['parent_id'] ?? null,
+            'date_created' => $category['created_at'],
+            'last_updated' => $category['updated_at']
+        ];
+    }
+    return null;
+}
+
+/**
+ * Retrieves all categories.
+ *
+ * @param mysqli $mysqli The database connection object.
+ * @return array An array of category associative arrays, or an empty array on failure or if no categories.
+ */
+function get_all_categories(mysqli $mysqli): array {
+    $sql = "SELECT category_id, category_name, category_description, category_slug, parent_id, created_at, updated_at FROM categories ORDER BY category_name ASC";
+    $stmt = $mysqli->prepare($sql);
+    if (!$stmt) {
+        error_log("Error preparing statement for get_all_categories: " . $mysqli->error);
+        return [];
+    }
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $categories = [];
+    if ($result) {
+        while ($row = $result->fetch_assoc()) {
+            $categories[] = [
+                'id' => $row['category_id'],
+                'name' => $row['category_name'],
+                'description' => $row['category_description'],
+                'slug' => $row['category_slug'],
+                'parent_id' => $row['parent_id'] ?? null,
+                'date_created' => $row['created_at'],
+                'last_updated' => $row['updated_at']
+            ];
+        }
+    }
+    return $categories;
+}
+
+/**
+ * Updates an existing category.
+ *
+ * @param mysqli $mysqli The database connection object.
+ * @param int $id The ID of the category to update.
+ * @param string $name The new name of the category.
+ * @param string|null $description The new description of the category.
+ * @param string $slug The new URL-friendly slug for the category.
+ * @param int|null $parent_id The new parent ID of the category.
+ * @return bool True on success, false on failure.
+ */
+function update_category(mysqli $mysqli, int $id, string $name, ?string $description, string $slug, ?int $parent_id = null): bool {
+    // last_updated is handled by ON UPDATE CURRENT_TIMESTAMP in schema.sql
+    $sql = "UPDATE categories SET category_name = ?, category_description = ?, category_slug = ?, parent_id = ? WHERE category_id = ?";
+    $stmt = $mysqli->prepare($sql);
+    if (!$stmt) {
+        error_log("Error preparing statement for update_category: " . $mysqli->error);
+        return false;
+    }
+    // Parameters: category_name, category_description, category_slug, parent_id, category_id
+    $stmt->bind_param("sssii", $name, $description, $slug, $parent_id, $id);
+
+    if ($stmt->execute()) {
+        // $stmt->affected_rows could be 0 if the data was the same.
+        // Success means the query ran without error.
+        return true;
+    } else {
+        error_log("Error executing statement for update_category: " . $stmt->error);
+        return false;
+    }
+}
+
+
+/**
+ * Deletes a category.
+ *
+ * @param mysqli $mysqli The database connection object.
+ * @param int $id The ID of the category to delete.
+ * @return bool True on success, false on failure.
+ */
+function delete_category(mysqli $mysqli, int $id): bool {
+    // Check for child categories IF parent_id column exists and is part of the logic.
+    // Assuming 'parent_id' is a column in 'categories' table for this check to be meaningful.
+    $sql_check_children = "SELECT COUNT(*) as child_count FROM categories WHERE parent_id = ?";
+    $stmt_check = $mysqli->prepare($sql_check_children);
+
+    if (!$stmt_check) {
+        // If parent_id column doesn't exist, this prepare might fail.
+        // Or it might succeed but child_count will always be 0 if no rows have parent_id = $id.
+        // Log error and proceed with deletion attempt if prepare fails for this check,
+        // as the main goal is to delete the category.
+        error_log("Error preparing statement for delete_category (check children): " . $mysqli->error . ". Proceeding with delete attempt.");
+    } else {
+        $stmt_check->bind_param("i", $id);
+        $stmt_check->execute();
+        $result_check = $stmt_check->get_result();
+        if ($result_check) {
+            $child_count = $result_check->fetch_assoc()['child_count'];
+            if ($child_count > 0) {
+                error_log("Attempted to delete category ID {$id} which has {$child_count} child categories. Deletion aborted.");
+                $stmt_check->close();
+                return false;
+            }
+        }
+        $stmt_check->close();
+    }
+
+    // products.category_id has ON DELETE SET NULL from schema.sql
+    $sql = "DELETE FROM categories WHERE category_id = ?";
+    $stmt = $mysqli->prepare($sql);
+    if (!$stmt) {
+        error_log("Error preparing statement for delete_category: " . $mysqli->error);
+        return false;
+    }
+    $stmt->bind_param("i", $id);
+
+    if ($stmt->execute()) {
+        return $stmt->affected_rows > 0;
+    } else {
+        error_log("Error executing statement for delete_category: " . $stmt->error);
+        return false;
+    }
+}
+
+?>

--- a/schema.sql
+++ b/schema.sql
@@ -1,14 +1,30 @@
--- Categories Table
-CREATE TABLE categories (
-    category_id INT AUTO_INCREMENT PRIMARY KEY,
-    category_name VARCHAR(255) NOT NULL UNIQUE,
-    category_slug VARCHAR(255) NOT NULL UNIQUE,
-    category_description TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-);
+-- Drop tables if they exist, in an order that respects foreign key constraints
+SET FOREIGN_KEY_CHECKS = 0; -- Disable foreign key checks to allow arbitrary drop order (simplifies this)
 
-CREATE INDEX idx_category_slug ON categories(category_slug);
+DROP TABLE IF EXISTS `order_items`;
+DROP TABLE IF EXISTS `orders`;
+DROP TABLE IF EXISTS `products`;
+DROP TABLE IF EXISTS `categories`;
+DROP TABLE IF EXISTS `customers`;
+DROP TABLE IF EXISTS `admins`;
+
+SET FOREIGN_KEY_CHECKS = 1; -- Re-enable foreign key checks
+
+-- Categories Table
+CREATE TABLE `categories` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `description` text,
+  `slug` varchar(255) NOT NULL,
+  `parent_id` int DEFAULT NULL,
+  `date_created` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_updated` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `slug` (`slug`),
+  UNIQUE KEY `name` (`name`),
+  KEY `idx_category_parent` (`parent_id`),
+  CONSTRAINT `fk_category_parent` FOREIGN KEY (`parent_id`) REFERENCES `categories` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- Products Table
 CREATE TABLE products (
@@ -23,7 +39,7 @@ CREATE TABLE products (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_product_category
-        FOREIGN KEY (category_id) REFERENCES categories(category_id)
+        FOREIGN KEY (category_id) REFERENCES categories(id) -- Updated to reference categories(id)
         ON DELETE SET NULL -- If a category is deleted, products are not deleted but category_id is set to NULL
         ON UPDATE CASCADE -- If category_id in categories table changes, update it here too
 );


### PR DESCRIPTION
This commit introduces the first phase of PHP backend development, focusing on category management.

Key changes include:
- Updated `schema.sql`:
    - Added `parent_id` to the `categories` table for hierarchical structures.
    - Standardized column names in the `categories` table.
    - Updated the `products` table foreign key to `categories`.
    - Prepended `DROP TABLE IF EXISTS` statements (with `SET FOREIGN_KEY_CHECKS`) for all tables to make the script idempotent.
- Database Configuration (`php/config.php`): Stores DB connection parameters.
- Database Connection (`php/db_connect.php`): Provides a reusable MySQLi connection.
- Category Functions (`php/includes/category_functions.php`): Encapsulates CRUD logic for categories using prepared statements.
- Admin Category Management Pages:
    - `admin/categories.php`: Lists categories, with links to add, edit, and delete.
    - `admin/category_form.php`: Provides a form for creating and editing categories, including parent selection.
    - `admin/category_delete.php`: Handles category deletion requests.
- Basic error handling and session-based user feedback are implemented on admin pages.